### PR TITLE
Additional Config Option

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -4,10 +4,13 @@
  * @param {String} stateName Redux store key for offline queue state.
  * @param {Array<String>} additionalTriggers An array of action types
  * that will trigger the offline queue to dispatch its actions if possible.
+ * @param {Boolean} dontDispatchActionAfterQueue If this is true an action
+ * that is queued will NOT dispatch instantly or go to the next middleware.
  */
 const DEFAULT_CONFIG = {
   stateName: 'offline',
   additionalTriggers: [],
+  dontDispatchActionAfterQueue: false,
 }
 
 /**

--- a/src/offlineMiddleware.js
+++ b/src/offlineMiddleware.js
@@ -63,7 +63,11 @@ function fireQueuedActions(queue, dispatch) {
 export default function offlineMiddleware(userConfig = {}) {
   return ({ getState, dispatch }) => next => (action) => {
     const config = getConfig(userConfig)
-    const { stateName, additionalTriggers } = config
+    const {
+      stateName,
+      additionalTriggers,
+      dontDispatchActionAfterQueue,
+    } = config
 
     const state = _.get(getState(), stateName, INITIAL_STATE)
 
@@ -100,6 +104,8 @@ export default function offlineMiddleware(userConfig = {}) {
       skipSaga: true,
     }
 
-    return next(skipSagaAction)
+    if (dontDispatchActionAfterQueue === false) {
+      return next(skipSagaAction)
+    }
   }
 }


### PR DESCRIPTION
Add additional config option to allow the queued action to not continue along the middleware after being added to the queue.

Reason:
When using `redux-offline-queue` in my current project I didn't want the action to continue along to the other middleware and be dispatched, I only wanted it to be added to the offline queue. 